### PR TITLE
Corrected afk time in kick reason

### DIFF
--- a/Addons/Admin/afk-kick.lua
+++ b/Addons/Admin/afk-kick.lua
@@ -16,7 +16,7 @@ Event.register(-1,function(event)
         for _,player in pairs(game.connected_players) do
             local afk = Ranking.get_rank(player).max_afk_time or false
             if afk then
-                if player.afk_time > afk*3600 then game.kick_player(player,'AFK For Too Long ('..tostring(afk*3600)..' Minutes)') end
+                if player.afk_time > afk*3600 then game.kick_player(player,'AFK For Too Long ('..tostring(afk)..' Minutes)') end
             end
         end
     end):on_event('error',function(self,err)


### PR DESCRIPTION
I recently saw a user (under one hour), kicked for being afk for 36,000 minutes.

![afk_kick](https://user-images.githubusercontent.com/12204953/37650205-3e35040c-2c02-11e8-8488-a2b750573460.jpg)