### PR TITLE
Fix repair command

### DIFF
--- a/Addons/Commands/repair.lua
+++ b/Addons/Commands/repair.lua
@@ -29,7 +29,7 @@ commands.add_command('repair', 'Repairs all destoryed and damaged entites in an 
     local center = player and player.position or {x=0,y=0}
     if not range or max_range and range > max_range then player_return({'commands.invalid-range',0,math.floor(max_range)}) return commands.error end
     local area = {{center.x-range,center.y-range},{center.x+range,center.y+range}}
-    local max_health = 2^32 - 1
+    local max_time_to_live = 2^32 - 1
     local sq_range = range^2
     for key, entity in pairs(player.surface.find_entities_filtered({area=area,type='entity-ghost'})) do
         if entity.force == player.force and (entity.position.x-center.x)^2+(entity.position.y-center.y)^2 < sq_range then
@@ -37,7 +37,7 @@ commands.add_command('repair', 'Repairs all destoryed and damaged entites in an 
                 player_return('You have repaired: '..entity.name..' this item is not allowed.',defines.text_color.crit,player)
                 Admin.temp_ban(player,'<server>','Attempt To Repair A Banned Item')
                 entity.destroy()
-            elseif entity.time_to_live ~= max_health then
+            elseif entity.time_to_live ~= max_time_to_live then
                 entity.revive() end
         end
     end


### PR DESCRIPTION
I have...
- optimized /repair by making only one call to find entities and filtering out entities outside of the repair radius
- fixed repairing entities not sharing a force with the player which prevents healing enemies or trees/rocks
- fixed reviving ghosts which were placed by the player (not from being destroyed) which allowed for repairing technologies that were not researched or were otherwise unavailable